### PR TITLE
Fix archive containing a single invalid symbol

### DIFF
--- a/Unpack.pm
+++ b/Unpack.pm
@@ -1081,7 +1081,7 @@ sub unpack
 
 	      # die Dumper "_run_mime_helper: $archive, $new_name, $destdir", readlink($unpacked), $unpacked;
 
-              unless (ref $unpacked or -e $unpacked)
+              unless (ref $unpacked or -e $unpacked or readlink($unpacked))
                 {
                   warn("archive=$archive, new_name=$new_name\n");
 		  die("assert -e '$unpacked'") 


### PR DESCRIPTION
If an archive contains a single symbol whose target doesn't exist
(like gcc's libgo testsuite for the tar module) then neither
ref $unpacked nor -e $unpacked is true (because unpacking causes
no error, but still the file doesn't exist in -e parlance).  The
if cascade after it explicitely checks for symlink-ness of
$unpacked and does the right thing (removing it), so just don't
die prematurely if $unpacked is a symlink.