### PR TITLE
Fix man page generation race

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -55,6 +55,7 @@ sub MY::postamble
   return q{
 file_unpack: file_unpack.pl Makefile
 	$(CP) file_unpack.pl $@
+	mkdir -p $(INST_MAN1DIR)
 	## wait, so that -M < -M succeeds in ExtUtils/Command/MM.pm
 	(sleep 1; echo .nf; $(PERL) $@ --help) > $(INST_MAN1DIR)/$@.1 || true
 };


### PR DESCRIPTION
Fix man page generation race.
Without this patch, it was
randomly missing a man-page part.

See https://reproducible-builds.org/ for why this is good.