### PR TITLE
Increase file limit a little bit for very large cpio archives

### DIFF
--- a/Unpack.pm
+++ b/Unpack.pm
@@ -1662,7 +1662,7 @@ sub _unused_pathname
       ## try to come up with a very similar name, just different suffix.
       ## be compatible with path name shortening in unpack()
       my $test_path = $wanted_path . '._';
-      for my $i ('', 1..999)
+      for my $i ('', 1..99999)
         {
 	  # All our mime detectors work on file contents, rather than on suffixes.
 	  # Thus messing with the suffix should be okay here.


### PR DESCRIPTION
```
_unused_pathname failed: last attempt...
```
This is a little problem we ran into with [Cavil](https://github.com/openSUSE/cavil). The openSUSE `cockpit` package will in the future bundle all its required node modules in a huge cpio archive, which can easily reach 1500+. While i believe that the algorithm as a whole could probably be improved so it doesn't have to re-run the whole loop for each file, this quick fix solves the immediate problem for us.